### PR TITLE
Add purchase notifications and admin purchase viewer

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -68,12 +68,14 @@ def start_operation(user_id: int, value: int, operation_id: str, message_id: int
 
 
 def add_bought_item(item_name: str, value: str, price: int, buyer_id: int,
-                    bought_time: str) -> None:
+                    bought_time: str) -> int:
     session = Database().session
+    unique_id = random.randint(1000000000, 9999999999)
     session.add(
         BoughtGoods(name=item_name, value=value, price=price, buyer_id=buyer_id, bought_datetime=bought_time,
-                    unique_id=str(random.randint(1000000000, 9999999999))))
+                    unique_id=str(unique_id)))
     session.commit()
+    return unique_id
 
 
 def create_promocode(code: str, discount: int, expires_at: str | None) -> None:

--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -207,6 +207,19 @@ def bought_items_list(buyer_id: int) -> list[str]:
         Database().session.query(BoughtGoods.item_name).filter(BoughtGoods.buyer_id == buyer_id).all()]
 
 
+def get_purchase_dates() -> list[str]:
+    return [d[0] for d in Database().session.query(func.date(BoughtGoods.bought_datetime)).distinct().all()]
+
+
+def get_purchases_by_date(date: str) -> list[dict]:
+    rows = (
+        Database().session.query(BoughtGoods)
+        .filter(func.date(BoughtGoods.bought_datetime) == date)
+        .all()
+    )
+    return [r.__dict__ for r in rows]
+
+
 def select_all_users() -> int:
     return Database().session.query(func.count()).filter(User).scalar()
 

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -12,6 +12,7 @@ from bot.handlers.admin.shop_management_states import register_shop_management
 from bot.handlers.admin.user_management_states import register_user_management
 from bot.handlers.admin.assistant_management_states import register_assistant_management
 from bot.handlers.admin.view_stock import register_view_stock
+from bot.handlers.admin.purchases import register_purchases
 from bot.handlers.other import get_bot_user_ids
 
 
@@ -44,7 +45,8 @@ async def admin_help_callback_handler(call: CallbackQuery):
 
 def register_admin_handlers(dp: Dispatcher) -> None:
     dp.register_callback_query_handler(console_callback_handler,
-                                       lambda c: c.data == 'console')
+                                       lambda c: c.data == 'console',
+                                       state='*')
     dp.register_callback_query_handler(admin_help_callback_handler,
                                        lambda c: c.data == 'admin_help',
                                        state='*')
@@ -54,3 +56,4 @@ def register_admin_handlers(dp: Dispatcher) -> None:
     register_user_management(dp)
     register_assistant_management(dp)
     register_view_stock(dp)
+    register_purchases(dp)

--- a/bot/handlers/admin/purchases.py
+++ b/bot/handlers/admin/purchases.py
@@ -1,0 +1,115 @@
+import os
+from aiogram import Dispatcher
+from aiogram.types import CallbackQuery
+
+from bot.database.methods import (
+    get_purchase_dates,
+    get_purchases_by_date,
+    select_bought_item,
+    check_user,
+    get_item_info,
+    get_category_parent,
+)
+from bot.handlers.other import get_bot_user_ids
+from bot.keyboards import (
+    purchases_dates_list,
+    purchases_list,
+    purchase_info_menu,
+)
+from bot.misc import TgConfig
+
+
+async def pirkimai_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    dates = get_purchase_dates()
+    await bot.edit_message_text(
+        '📅 Choose date',
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=purchases_dates_list(dates),
+    )
+
+
+async def purchases_date_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    date = call.data[len('purchases_date_'):]
+    purchases = get_purchases_by_date(date)
+    await bot.edit_message_text(
+        f'📦 Purchases {date}',
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=purchases_list(purchases, date),
+    )
+
+
+async def purchase_info_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    _, purchase_id, date = call.data.split('_', 2)
+    purchase_id_int = int(purchase_id)
+    purchase = select_bought_item(purchase_id_int)
+    if not purchase:
+        await call.answer('Not found', show_alert=True)
+        return
+    buyer = check_user(purchase['buyer_id'])
+    username = f'@{buyer.username}' if buyer and buyer.username else str(purchase['buyer_id'])
+    item_info = get_item_info(purchase['item_name'])
+    parent_cat = get_category_parent(item_info['category_name'])
+    path_guess = purchase['value']
+    sold_path = os.path.join(os.path.dirname(path_guess), 'Sold', os.path.basename(path_guess))
+    desc = ''
+    desc_file = f"{sold_path}.txt"
+    if os.path.isfile(desc_file):
+        with open(desc_file) as f:
+            desc = f.read()
+    text = (
+        f"User {username}\n"
+        f"Time: {purchase['bought_datetime']} GMT+3\n"
+        f"Product: {purchase['item_name']} ({purchase['price']}€)\n"
+        f"Crypto: N/A\n"
+        f"Category: {parent_cat or '-'} / {item_info['category_name']}\n"
+        f"Description: {desc or '-'}\n"
+        f"File: {sold_path}"
+    )
+    await bot.edit_message_text(
+        text,
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=purchase_info_menu(purchase_id_int, date),
+    )
+
+
+async def view_purchase_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    purchase_id = call.data[len('view_purchase_'):]
+    purchase = select_bought_item(int(purchase_id))
+    if not purchase:
+        await call.answer('Not found', show_alert=True)
+        return
+    path = purchase['value']
+    sold_path = os.path.join(os.path.dirname(path), 'Sold', os.path.basename(path))
+    if os.path.isfile(sold_path):
+        path = sold_path
+    desc = ''
+    desc_file = f"{path}.txt"
+    if os.path.isfile(desc_file):
+        with open(desc_file) as f:
+            desc = f.read()
+    if os.path.isfile(path):
+        with open(path, 'rb') as media:
+            if path.endswith('.mp4'):
+                await bot.send_video(user_id, media, caption=desc or None)
+            else:
+                await bot.send_photo(user_id, media, caption=desc or None)
+    else:
+        await bot.send_message(user_id, purchase['value'])
+    await call.answer()
+
+
+def register_purchases(dp: Dispatcher) -> None:
+    dp.register_callback_query_handler(pirkimai_callback_handler, lambda c: c.data == 'pirkimai', state='*')
+    dp.register_callback_query_handler(purchases_date_callback_handler, lambda c: c.data.startswith('purchases_date_'), state='*')
+    dp.register_callback_query_handler(purchase_info_callback_handler, lambda c: c.data.startswith('purchase_'), state='*')
+    dp.register_callback_query_handler(view_purchase_handler, lambda c: c.data.startswith('view_purchase_'), state='*')

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -139,6 +139,7 @@ def console(role: int) -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
     inline_keyboard = [
+        [InlineKeyboardButton('🛒 Pirkimai', callback_data='pirkimai')],
         [InlineKeyboardButton('🏪 Parduotuvės valdymas', callback_data='shop_management')],
         [InlineKeyboardButton('👥 Vartotojų valdymas', callback_data='user_management')],
         [InlineKeyboardButton('📢 Pranešimų siuntimas', callback_data='send_message')],
@@ -177,6 +178,34 @@ def user_management(admin_role: int, user_role: int, admin_manage: int, items: i
                 [InlineKeyboardButton('⬇️ Remove admin', callback_data=f'remove-admin_{user_id}')])
     inline_keyboard.append([InlineKeyboardButton('🔙 Go back', callback_data='user_management')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def purchases_dates_list(dates: list[str]) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup()
+    for d in dates:
+        markup.add(InlineKeyboardButton(d, callback_data=f'purchases_date_{d}'))
+    markup.add(InlineKeyboardButton('🔙 Go back', callback_data='console'))
+    return markup
+
+
+def purchases_list(purchases: list[dict], date: str) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup()
+    for p in purchases:
+        markup.add(
+            InlineKeyboardButton(
+                f"{p['unique_id']} - {display_name(p['item_name'])}",
+                callback_data=f"purchase_{p['unique_id']}_{date}"
+            )
+        )
+    markup.add(InlineKeyboardButton('🔙 Go back', callback_data='pirkimai'))
+    return markup
+
+
+def purchase_info_menu(purchase_id: int, date: str) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup()
+    markup.add(InlineKeyboardButton('👁 View file', callback_data=f'view_purchase_{purchase_id}'))
+    markup.add(InlineKeyboardButton('🔙 Go back', callback_data=f'purchases_date_{date}'))
+    return markup
 
 
 def user_manage_check(user_id: int) -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- Notify the owner with detailed info after each purchase and let them view the item on demand
- Add "Pirkimai" admin panel to review purchases by date and item
- Fix back navigation by handling callbacks regardless of state

## Testing
- `python -m py_compile database/methods/create.py database/methods/read.py handlers/user/main.py handlers/admin/purchases.py handlers/admin/main.py keyboards/inline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4d60a4d5c8332968fc72e2f52e8df